### PR TITLE
Enable catching non pull request commits in repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ mainClassName = 'reposense.RepoSense'
 
 node.nodeVersion = '10.16.0'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ mainClassName = 'reposense.RepoSense'
 
 node.nodeVersion = '10.16.0'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     mavenCentral()

--- a/config/repo-config.csv
+++ b/config/repo-config.csv
@@ -1,10 +1,10 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
-https://github.com/reposense/testrepo-Alpha.git,master,,,,2fb6b9b2dd9fa40bf0f9815da2cb0ae8731436c7;c5a6dc774e22099cd9ddeb0faff1e75f9cf4f151;cd7f610e0becbdf331d5231887d8010a689f87c7;768015345e70f06add2a8b7d1f901dc07bf70582,,
-https://github.com/reposense/testrepo-Beta.git,master,fxml,docs**,yes,,,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,fxml,docs**,yes,,,
-https://github.com/reposense/testrepo-Delta.git,master,override:java;md,,,,,
-https://github.com/reposense/testrepo-Delta.git,nonExistentBranch,,,,,,
-https://github.com/reposense/testrepo-Delta.git,add-binary-file,,,,,,
-https://github.com/reposense/RepoSense.git,master,,,,,,
-https://github.com/reposense/testrepo-Empty.git,master,,,,,,
-ftp://github.com/reposense/RepoSense.git,master,,,,,,
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning,Catch Non PR Commits
+https://github.com/reposense/testrepo-Alpha.git,master,,,,2fb6b9b2dd9fa40bf0f9815da2cb0ae8731436c7;c5a6dc774e22099cd9ddeb0faff1e75f9cf4f151;cd7f610e0becbdf331d5231887d8010a689f87c7;768015345e70f06add2a8b7d1f901dc07bf70582,,,
+https://github.com/reposense/testrepo-Beta.git,master,fxml,docs**,yes,,,,
+https://github.com/reposense/testrepo-Beta.git,add-config-json,fxml,docs**,yes,,,,
+https://github.com/reposense/testrepo-Delta.git,master,override:java;md,,,,,,
+https://github.com/reposense/testrepo-Delta.git,nonExistentBranch,,,,,,,
+https://github.com/reposense/testrepo-Delta.git,add-binary-file,,,,,,,
+https://github.com/reposense/RepoSense.git,master,,,,,,,yes
+https://github.com/reposense/testrepo-Empty.git,master,,,,,,,
+ftp://github.com/reposense/RepoSense.git,master,,,,,,,yes

--- a/config/repo-config.csv
+++ b/config/repo-config.csv
@@ -1,10 +1,2 @@
 Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning,Catch Non PR Commits
-https://github.com/reposense/testrepo-Alpha.git,master,,,,2fb6b9b2dd9fa40bf0f9815da2cb0ae8731436c7;c5a6dc774e22099cd9ddeb0faff1e75f9cf4f151;cd7f610e0becbdf331d5231887d8010a689f87c7;768015345e70f06add2a8b7d1f901dc07bf70582,,,
-https://github.com/reposense/testrepo-Beta.git,master,fxml,docs**,yes,,,,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,fxml,docs**,yes,,,,
-https://github.com/reposense/testrepo-Delta.git,master,override:java;md,,,,,,
-https://github.com/reposense/testrepo-Delta.git,nonExistentBranch,,,,,,,
-https://github.com/reposense/testrepo-Delta.git,add-binary-file,,,,,,,
-https://github.com/reposense/RepoSense.git,master,,,,,,,yes
-https://github.com/reposense/testrepo-Empty.git,master,,,,,,,
-ftp://github.com/reposense/RepoSense.git,master,,,,,,,yes
+https://github.com/FH-30/Test-Repo.git,master,,,,,,,yes

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -74,6 +74,9 @@ public class RepoSense {
                     cliArguments.isLastModifiedDateIncluded());
             RepoConfiguration.setIsShallowCloningPerformedToRepoConfigs(configs,
                     cliArguments.isShallowCloningPerformed());
+            RepoConfiguration.setIsCatchingNonPrCommitsPerformedToRepoConfigs(configs,
+                    cliArguments.isCatchingNonPrCommitsPerformed());
+
             List<Path> reportFoldersAndFiles = ReportGenerator.generateReposReport(configs,
                     cliArguments.getOutputFilePath().toAbsolutePath().toString(),
                     cliArguments.getAssetsFilePath().toAbsolutePath().toString(), reportConfig,

--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -7,7 +7,14 @@ import java.net.URLConnection;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -43,6 +50,7 @@ public class CommitInfoAnalyzer {
     private static final String REF_SPLITTER = ",\\s";
     private static final String NEW_LINE_SPLITTER = "\\n";
     private static final String TAG_PREFIX = "tag:";
+    private static final String PR_COMMIT_INDICATOR = "class=\"pull-request\"";
 
     private static final int COMMIT_HASH_INDEX = 0;
     private static final int AUTHOR_INDEX = 1;
@@ -134,7 +142,7 @@ public class CommitInfoAnalyzer {
         String githubCommitUrl = getGithubQueryUrl(config, hash);
         String htmlContainingPrUrl = getHtml(githubCommitUrl);
 
-        boolean isNonPrCommit = !htmlContainingPrUrl.contains("class=\"pull-request\"");
+        boolean isNonPrCommit = !htmlContainingPrUrl.contains(PR_COMMIT_INDICATOR);
 
         String[] refs = (elements.length > REF_NAME_INDEX)
                 ? elements[REF_NAME_INDEX].split(REF_SPLITTER)
@@ -163,7 +171,7 @@ public class CommitInfoAnalyzer {
      * Returns the number of lines added and deleted for the specified file types in {@code config}.
      */
     private static Map<FileType, ContributionPair> getFileTypesAndContribution(String[] filePathContributions,
-            RepoConfiguration config) {
+                                                                               RepoConfiguration config) {
         Map<FileType, ContributionPair> fileTypesAndContributionMap = new HashMap<>();
         for (String filePathContribution : filePathContributions) {
             String[] infos = filePathContribution.split(TAB_SPLITTER);

--- a/src/main/java/reposense/commits/CommitResultAggregator.java
+++ b/src/main/java/reposense/commits/CommitResultAggregator.java
@@ -40,6 +40,9 @@ public class CommitResultAggregator {
                 getAuthorDailyContributionsMap(config.getAuthorDisplayNameMap().keySet(), commitResults,
                         config.getZoneId());
 
+        Map<Author, Integer> authorNonPrCommitsMap = getAuthorNonPrCommitsMap(
+                config.getAuthorDisplayNameMap().keySet(), commitResults);
+
         Date lastDate = commitResults.size() == 0
                 ? null
                 : getStartOfDate(commitResults.get(commitResults.size() - 1).getTime(), config.getZoneId());
@@ -50,7 +53,8 @@ public class CommitResultAggregator {
         return new CommitContributionSummary(
                 config.getAuthorDisplayNameMap(),
                 authorDailyContributionsMap,
-                authorContributionVariance);
+                authorContributionVariance,
+                authorNonPrCommitsMap);
     }
 
     /**
@@ -119,6 +123,26 @@ public class CommitResultAggregator {
         }
 
         return authorDailyContributionsMap;
+    }
+
+    private static Map<Author, Integer> getAuthorNonPrCommitsMap (Set<Author> authorSet,
+                                                                  List<CommitResult> commitResults) {
+        Map<Author, Integer> authorNonPrCommitsMap = new HashMap<>();
+        authorSet.forEach(author -> authorNonPrCommitsMap.put(author, 0));
+
+        for (CommitResult commitResult : commitResults) {
+            Author commitAuthor = commitResult.getAuthor();
+
+            Integer authorNonPrCommits = authorNonPrCommitsMap.get(commitAuthor);
+
+            if (commitResult.isNonPrCommit()) {
+                authorNonPrCommits++;
+            }
+
+            authorNonPrCommitsMap.put(commitAuthor, authorNonPrCommits);
+        }
+
+        return authorNonPrCommitsMap;
     }
 
     private static void addDailyContributionForNewDate(

--- a/src/main/java/reposense/commits/model/CommitContributionSummary.java
+++ b/src/main/java/reposense/commits/model/CommitContributionSummary.java
@@ -12,14 +12,17 @@ public class CommitContributionSummary {
     private final Map<Author, List<AuthorDailyContribution>> authorDailyContributionsMap;
     private final Map<Author, Float> authorContributionVariance;
     private final Map<Author, String> authorDisplayNameMap;
+    private final Map<Author, Integer> authorNonPrCommitsMap;
 
     public CommitContributionSummary(
             Map<Author, String> authorDisplayNameMap,
             Map<Author, List<AuthorDailyContribution>> authorDailyContributionsMap,
-            Map<Author, Float> authorContributionVariance) {
+            Map<Author, Float> authorContributionVariance,
+            Map<Author, Integer> authorNonPrCommitsMap) {
         this.authorDisplayNameMap = authorDisplayNameMap;
         this.authorDailyContributionsMap = authorDailyContributionsMap;
         this.authorContributionVariance = authorContributionVariance;
+        this.authorNonPrCommitsMap = authorNonPrCommitsMap;
     }
 
     public Map<Author, String> getAuthorDisplayNameMap() {
@@ -33,4 +36,6 @@ public class CommitContributionSummary {
     public Map<Author, Float> getAuthorContributionVariance() {
         return authorContributionVariance;
     }
+
+    public Map<Author, Integer> getAuthorNonPrCommitsMap() { return authorNonPrCommitsMap; }
 }

--- a/src/main/java/reposense/commits/model/CommitResult.java
+++ b/src/main/java/reposense/commits/model/CommitResult.java
@@ -15,29 +15,33 @@ public class CommitResult {
     private final String hash;
     private final String messageTitle;
     private final String messageBody;
+    private final boolean isNonPrCommit;
     private final String[] tags;
     private final Map<FileType, ContributionPair> fileTypesAndContributionMap;
 
     private final transient Author author;
     private final transient Date time;
 
-    public CommitResult(Author author, String hash, Date time, String messageTitle, String messageBody, String[] tags,
-            Map<FileType, ContributionPair> fileTypesAndContributionMap) {
+    public CommitResult(Author author, String hash, Date time, String messageTitle, String messageBody,
+                        boolean isNonPrCommit, String[] tags, Map<FileType, ContributionPair> fileTypesAndContributionMap) {
         this.author = author;
         this.hash = hash;
         this.time = time;
         this.messageTitle = messageTitle;
         this.messageBody = messageBody;
+        this.isNonPrCommit = isNonPrCommit;
         this.tags = tags;
         this.fileTypesAndContributionMap = fileTypesAndContributionMap;
     }
 
-    public CommitResult(Author author, String hash, Date time, String messageTitle, String messageBody, String[] tags) {
+    public CommitResult(Author author, String hash, Date time, String messageTitle, String messageBody,
+                        boolean isNonPrCommit, String[] tags) {
         this.author = author;
         this.hash = hash;
         this.time = time;
         this.messageTitle = messageTitle;
         this.messageBody = messageBody;
+        this.isNonPrCommit = isNonPrCommit;
         this.tags = tags;
         this.fileTypesAndContributionMap = Collections.emptyMap();
     }
@@ -65,6 +69,8 @@ public class CommitResult {
     public Date getTime() {
         return time;
     }
+
+    public boolean isNonPrCommit() { return isNonPrCommit; }
 
     public int getInsertions() {
         int insertions = 0;

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -20,6 +20,7 @@ public abstract class CliArguments {
     protected boolean isShallowCloningPerformed;
     protected boolean isAutomaticallyLaunching;
     protected boolean isStandaloneConfigIgnored;
+    protected boolean isCatchingNonPrCommitsPerformed;
     protected int numCloningThreads;
     protected int numAnalysisThreads;
     protected ZoneId zoneId;
@@ -59,6 +60,8 @@ public abstract class CliArguments {
     public boolean isShallowCloningPerformed() {
         return isShallowCloningPerformed;
     }
+
+    public boolean isCatchingNonPrCommitsPerformed() { return isCatchingNonPrCommitsPerformed; }
 
     public List<FileType> getFormats() {
         return formats;

--- a/src/main/java/reposense/model/ConfigCliArguments.java
+++ b/src/main/java/reposense/model/ConfigCliArguments.java
@@ -27,7 +27,7 @@ public class ConfigCliArguments extends CliArguments {
     public ConfigCliArguments(Path configFolderPath, Path outputFilePath, Path assetsFilePath, Date sinceDate,
             Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
             int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
-            boolean isShallowCloningPerformed, boolean isAutomaticallyLaunching,
+            boolean isShallowCloningPerformed, boolean isCatchingNonPrCommitsPerformed, boolean isAutomaticallyLaunching,
             boolean isStandaloneConfigIgnored, ZoneId zoneId, ReportConfiguration reportConfiguration) {
         this.configFolderPath = configFolderPath.equals(EMPTY_PATH)
                 ? configFolderPath.toAbsolutePath()
@@ -45,6 +45,7 @@ public class ConfigCliArguments extends CliArguments {
         this.formats = formats;
         this.isLastModifiedDateIncluded = isLastModifiedDateIncluded;
         this.isShallowCloningPerformed = isShallowCloningPerformed;
+        this.isCatchingNonPrCommitsPerformed = isCatchingNonPrCommitsPerformed;
         this.isAutomaticallyLaunching = isAutomaticallyLaunching;
         this.isStandaloneConfigIgnored = isStandaloneConfigIgnored;
         this.numCloningThreads = numCloningThreads;

--- a/src/main/java/reposense/model/LocationsCliArguments.java
+++ b/src/main/java/reposense/model/LocationsCliArguments.java
@@ -14,7 +14,7 @@ public class LocationsCliArguments extends CliArguments {
     public LocationsCliArguments(List<String> locations, Path outputFilePath, Path assetsFilePath, Date sinceDate,
             Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
             int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
-            boolean isShallowCloningPerformed, boolean isAutomaticallyLaunching,
+            boolean isShallowCloningPerformed, boolean isCatchingNonPrCommitsPerformed, boolean isAutomaticallyLaunching,
             boolean isStandaloneConfigIgnored, ZoneId zoneId) {
         this.locations = locations;
         this.outputFilePath = outputFilePath;
@@ -25,6 +25,7 @@ public class LocationsCliArguments extends CliArguments {
         this.isUntilDateProvided = isUntilDateProvided;
         this.isLastModifiedDateIncluded = isLastModifiedDateIncluded;
         this.isShallowCloningPerformed = isShallowCloningPerformed;
+        this.isCatchingNonPrCommitsPerformed = isCatchingNonPrCommitsPerformed;
         this.formats = formats;
         this.isAutomaticallyLaunching = isAutomaticallyLaunching;
         this.isStandaloneConfigIgnored = isStandaloneConfigIgnored;

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -38,6 +38,7 @@ public class RepoConfiguration {
     private transient List<CommitHash> ignoreCommitList;
     private transient boolean isLastModifiedDateIncluded;
     private transient boolean isShallowCloningPerformed;
+    private transient boolean isCatchingNonPrCommitsPerformed;
     private transient boolean isFormatsOverriding;
     private transient boolean isIgnoreGlobListOverriding;
     private transient boolean isIgnoreCommitListOverriding;
@@ -49,13 +50,13 @@ public class RepoConfiguration {
 
     public RepoConfiguration(RepoLocation location, String branch) {
         this(location, branch, Collections.emptyList(), Collections.emptyList(), false, Collections.emptyList(),
-                false, false, false, false);
+                false, false, false, false, false);
     }
 
     public RepoConfiguration(RepoLocation location, String branch, List<FileType> formats, List<String> ignoreGlobList,
             boolean isStandaloneConfigIgnored, List<CommitHash> ignoreCommitList, boolean isFormatsOverriding,
             boolean isIgnoreGlobListOverriding, boolean isIgnoreCommitListOverriding,
-            boolean isShallowCloningPerformed) {
+            boolean isShallowCloningPerformed, boolean isCatchingNonPrCommitsPerformed) {
         this.authorConfig = new AuthorConfiguration(location, branch);
         this.location = location;
         this.branch = location.isEmpty() ? DEFAULT_BRANCH : branch;
@@ -67,6 +68,7 @@ public class RepoConfiguration {
         this.isIgnoreGlobListOverriding = isIgnoreGlobListOverriding;
         this.isIgnoreCommitListOverriding = isIgnoreCommitListOverriding;
         this.isShallowCloningPerformed = isShallowCloningPerformed;
+        this.isCatchingNonPrCommitsPerformed = isCatchingNonPrCommitsPerformed;
 
         String organization = location.getOrganization();
         String repoName = location.getRepoName();
@@ -105,6 +107,13 @@ public class RepoConfiguration {
                                                                  boolean isShallowCloningPerformed) {
         if (isShallowCloningPerformed) {
             configs.stream().forEach(config -> config.setIsShallowCloningPerformed(true));
+        }
+    }
+
+    public static void setIsCatchingNonPrCommitsPerformedToRepoConfigs(List<RepoConfiguration> configs,
+                                                                       boolean isCatchingNonPrCommitsPerformed) {
+        if (isCatchingNonPrCommitsPerformed) {
+            configs.stream().forEach(config -> config.setIsCatchingNonPrCommitsPerformed(true));
         }
     }
 
@@ -393,6 +402,10 @@ public class RepoConfiguration {
 
     public void setIsShallowCloningPerformed(boolean isShallowCloningPerformed) {
         this.isShallowCloningPerformed = isShallowCloningPerformed;
+    }
+
+    public void setIsCatchingNonPrCommitsPerformed(boolean isCatchingNonPrCommitsPerformed) {
+        this.isCatchingNonPrCommitsPerformed = isCatchingNonPrCommitsPerformed;
     }
 
     public boolean isLastModifiedDateIncluded() {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -56,6 +56,7 @@ public class ArgsParser {
     public static final String[] TIMEZONE_FLAGS = new String[]{"--timezone", "-t"};
     public static final String[] VERSION_FLAGS = new String[]{"--version", "-V"};
     public static final String[] LAST_MODIFIED_DATE_FLAGS = new String[]{"--last-modified-date", "-l"};
+    public static final String[] CATCH_NON_PR_COMMITS_FLAGS = new String[]{"--catch-non-pr-commits", "-C"};
 
     public static final String[] CLONING_THREADS_FLAG = new String[]{"--cloning-threads"};
     public static final String[] ANALYSIS_THREADS_FLAG = new String[]{"--analysis-threads"};
@@ -115,6 +116,12 @@ public class ArgsParser {
         parser.addArgument(VERSION_FLAGS)
                 .help("Show the version of RepoSense.")
                 .action(new VersionArgumentAction());
+
+        parser.addArgument(CATCH_NON_PR_COMMITS_FLAGS)
+                .dest(CATCH_NON_PR_COMMITS_FLAGS[0])
+                .action(Arguments.storeTrue())
+                .help("A flag to record the number of commits in the repository not merged from pull requests. "
+                        + "A breakdown will be provided for each author that contributed to the repository");
 
         parser.addArgument(IGNORE_FLAGS)
                 .dest(IGNORE_FLAGS[0])
@@ -257,6 +264,7 @@ public class ArgsParser {
             boolean isStandaloneConfigIgnored = results.get(IGNORE_FLAGS[0]);
             boolean shouldIncludeLastModifiedDate = results.get(LAST_MODIFIED_DATE_FLAGS[0]);
             boolean shouldPerformShallowCloning = results.get(SHALLOW_CLONING_FLAGS[0]);
+            boolean shouldCatchNonPrCommits = results.get(CATCH_NON_PR_COMMITS_FLAGS[0]);
 
             // Report config is ignored if --repos is provided
             if (locations == null) {
@@ -324,7 +332,7 @@ public class ArgsParser {
             if (locations != null) {
                 return new LocationsCliArguments(locations, outputFolderPath, assetsFolderPath, sinceDate, untilDate,
                         isSinceDateProvided, isUntilDateProvided, numCloningThreads, numAnalysisThreads, formats,
-                        shouldIncludeLastModifiedDate, shouldPerformShallowCloning, isAutomaticallyLaunching,
+                        shouldIncludeLastModifiedDate, shouldPerformShallowCloning, shouldCatchNonPrCommits, isAutomaticallyLaunching,
                         isStandaloneConfigIgnored, zoneId);
             }
 
@@ -333,7 +341,7 @@ public class ArgsParser {
             }
             return new ConfigCliArguments(configFolderPath, outputFolderPath, assetsFolderPath, sinceDate, untilDate,
                     isSinceDateProvided, isUntilDateProvided, numCloningThreads, numAnalysisThreads, formats,
-                    shouldIncludeLastModifiedDate, shouldPerformShallowCloning, isAutomaticallyLaunching,
+                    shouldIncludeLastModifiedDate, shouldPerformShallowCloning, shouldCatchNonPrCommits, isAutomaticallyLaunching,
                     isStandaloneConfigIgnored, zoneId, reportConfig);
         } catch (HelpScreenException hse) {
             throw hse;

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -18,6 +18,7 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     public static final String REPO_CONFIG_FILENAME = "repo-config.csv";
     private static final String IGNORE_STANDALONE_CONFIG_KEYWORD = "yes";
     private static final String SHALLOW_CLONING_CONFIG_KEYWORD = "yes";
+    private static final String CATCH_NON_PR_COMMITS_CONFIG_KEYWORD = "yes";
 
     /**
      * Positions of the elements of a line in repo-config.csv config file
@@ -30,6 +31,7 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     private static final String IGNORE_COMMIT_LIST_CONFIG_HEADER = "Ignore Commit List";
     private static final String IGNORE_AUTHOR_LIST_CONFIG_HEADER = "Ignore Authors List";
     private static final String SHALLOW_CLONING_CONFIG_HEADER = "Shallow Cloning";
+    private static final String CATCH_NON_PR_COMMITS_CONFIG_HEADER = "Catch Non PR Commits";
 
     public RepoConfigCsvParser(Path csvFilePath) throws IOException {
         super(csvFilePath);
@@ -53,6 +55,7 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
         return new String[] {
                 BRANCH_HEADER, FILE_FORMATS_HEADER, IGNORE_GLOB_LIST_HEADER, IGNORE_STANDALONE_CONFIG_HEADER,
                 IGNORE_COMMIT_LIST_CONFIG_HEADER, IGNORE_AUTHOR_LIST_CONFIG_HEADER, SHALLOW_CLONING_CONFIG_HEADER,
+                CATCH_NON_PR_COMMITS_CONFIG_HEADER,
         };
     }
 
@@ -98,10 +101,19 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
                     "Ignoring unknown value " + shallowCloningConfig + " in shallow cloning column.");
         }
 
+        String catchingNonPrCommitsConfig = get(record, CATCH_NON_PR_COMMITS_CONFIG_HEADER);
+        boolean isCatchingNonPrCommitsPerformed =
+                catchingNonPrCommitsConfig.equalsIgnoreCase(CATCH_NON_PR_COMMITS_CONFIG_KEYWORD);
+
+        if (!isCatchingNonPrCommitsPerformed && !catchingNonPrCommitsConfig.isEmpty()) {
+            logger.warning(
+                    "Ignoring unknown value " + catchingNonPrCommitsConfig + " in catch non pr commits column.");
+        }
+
         RepoConfiguration config = new RepoConfiguration(
                 location, branch, formats, ignoreGlobList, isStandaloneConfigIgnored, ignoreCommitList,
                 isFormatsOverriding, isIgnoreGlobListOverriding, isIgnoreCommitListOverriding,
-                isShallowCloningPerformed);
+                isShallowCloningPerformed, isCatchingNonPrCommitsPerformed);
         config.setIgnoredAuthorsList(ignoredAuthorsList);
         config.setIsIgnoredAuthorsListOverriding(isIgnoredAuthorsListOverriding);
 

--- a/src/main/java/reposense/report/CommitReportJson.java
+++ b/src/main/java/reposense/report/CommitReportJson.java
@@ -20,6 +20,7 @@ public class CommitReportJson {
     private final Map<Author, LinkedHashMap<FileType, Integer>> authorFileTypeContributionMap;
     private final Map<Author, Float> authorContributionVariance;
     private final Map<Author, String> authorDisplayNameMap;
+    private final Map<Author, Integer> authorNonPrCommitsMap;
 
     /**
      * Constructor to construct an empty commit report with the author's display name as {@code displayName}.
@@ -38,6 +39,9 @@ public class CommitReportJson {
 
         authorDisplayNameMap = new HashMap<>();
         authorDisplayNameMap.put(emptyAuthor, displayName);
+
+        authorNonPrCommitsMap = new HashMap<>();
+        authorNonPrCommitsMap.put(emptyAuthor, 0);
     }
 
     public CommitReportJson(CommitContributionSummary commitSummary, AuthorshipSummary authorshipSummary) {
@@ -45,5 +49,6 @@ public class CommitReportJson {
         authorFileTypeContributionMap = authorshipSummary.getAuthorFileTypeContributionMap();
         authorContributionVariance = commitSummary.getAuthorContributionVariance();
         authorDisplayNameMap = commitSummary.getAuthorDisplayNameMap();
+        authorNonPrCommitsMap = commitSummary.getAuthorNonPrCommitsMap();
     }
 }

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -142,7 +142,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         expectedCommitResults.add(new CommitResult(author, LATEST_COMMIT_HASH,
                 parseGitStrictIsoDate("2021-04-05T12:27:03+08:00"),
                 "Add test lines for disowned code",
-                "", null, fileTypeAndContributionMap));
+                "", false, null, fileTypeAndContributionMap));
 
         config.setAuthorList(Arrays.asList(author, author));
         config.setSinceDate(new GregorianCalendar(2021, Calendar.APRIL, 5).getTime());
@@ -168,12 +168,12 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
         expectedCommitResults.add(new CommitResult(author, "2eccc111e813e8b2977719b5959e32b674c56afe",
                 parseGitStrictIsoDate("2019-06-19T13:02:01+08:00"), ">>>COMMIT INFO<<<",
-                "Hi there!\n\n>>>COMMIT INFO<<<\n", null,
+                "Hi there!\n\n>>>COMMIT INFO<<<\n", false, null,
                 firstFileTypeAndContributionMap));
         expectedCommitResults.add(new CommitResult(author, "8f8359649361f6736c31b87d499a4264f6cf7ed7",
                 parseGitStrictIsoDate("2019-06-19T13:03:39+08:00"), "[#123] Reverted 1st commit",
                 "This is a test to see if the commit message body works. "
-                + "All should be same same.\n>>>COMMIT INFO<<<\n|The end.", null,
+                + "All should be same same.\n>>>COMMIT INFO<<<\n|The end.", false, null,
                 secondFileTypeAndContributionMap));
 
         config.setBranch("751-CommitInfoAnalyzerTest-analyzeCommits_multipleCommitsWithCommitMessageBody_success");
@@ -201,11 +201,11 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         // 1st test: Contains commit message title but no commit message body.
         expectedCommitResults.add(new CommitResult(author, "e54ae8fdb77c6c7d2c39131b816bfc03e6a6dd44",
                 parseGitStrictIsoDate("2019-07-02T12:35:46+08:00"), "Test 1: With message title but no body",
-                "", null, firstFileTypeAndContributionMap));
+                "", false, null, firstFileTypeAndContributionMap));
         // 2nd test: Contains no commit message title and no commit message body.
         expectedCommitResults.add(new CommitResult(author, "57fa22fc2550210203c2941692f69ccb0cf18252",
-                parseGitStrictIsoDate("2019-07-02T12:36:14+08:00"), "", "", null,
-                secondFileTypeAndContributionMap));
+                parseGitStrictIsoDate("2019-07-02T12:36:14+08:00"), "", "", false,
+                null, secondFileTypeAndContributionMap));
 
         config.setBranch("751-CommitInfoAnalyzerTest-analyzeCommits_commitsWithEmptyCommitMessageTitleOrBody_success");
         config.setAuthorList(Collections.singletonList(author));
@@ -231,10 +231,10 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
         expectedCommitResults.add(new CommitResult(author, "62c3a50ef9b3580b2070deac1eed2b3e2d701e04",
                 parseGitStrictIsoDate("2019-12-20T22:45:18+08:00"), "Single Tag Commit",
-                "", new String[] {"1st"}, firstFileTypeAndContributionMap));
+                "", false, new String[] {"1st"}, firstFileTypeAndContributionMap));
         expectedCommitResults.add(new CommitResult(author, "c5e36ec059390233ac036db61a84fa6b55952506",
                 parseGitStrictIsoDate("2019-12-20T22:47:21+08:00"), "Double Tag Commit",
-                "", new String[] {"2nd-tag", "1st-tag"}, secondFileTypeAndContributionMap));
+                "", false, new String[] {"2nd-tag", "1st-tag"}, secondFileTypeAndContributionMap));
 
         config.setBranch("879-CommitInfoAnalyzerTest-analyzeCommits_commitsWithMultipleTags_success");
         config.setAuthorList(Collections.singletonList(author));
@@ -253,7 +253,8 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         List<CommitResult> expectedCommitResults = new ArrayList<>();
 
         expectedCommitResults.add(new CommitResult(author, "016ab87c4afe89a98225b96c98ff28dd4774410f",
-                parseGitStrictIsoDate("2020-01-27T22:20:51+08:00"), "empty commit", "", null));
+                parseGitStrictIsoDate("2020-01-27T22:20:51+08:00"), "empty commit", "",
+                false, null));
 
         config.setBranch("1019-CommitInfoAnalyzerTest-emptyCommits");
         config.setAuthorList(Collections.singletonList(author));
@@ -274,7 +275,8 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
         // binary file contribution will have 0 contribution and won't be added to fileTypesAndContributionMap
         expectedCommitResults.add(new CommitResult(author, "a00c51138cbf5ab7d14f52b52abb182c8a369169",
-                parseGitStrictIsoDate("2020-04-06T16:41:10+08:00"), "Add binary file", "", null));
+                parseGitStrictIsoDate("2020-04-06T16:41:10+08:00"), "Add binary file", "",
+                false, null));
 
         config.setBranch("1192-CommitInfoAnalyzerTest-analyzeCommits_commitsWithBinaryContribution_success");
         config.setAuthorList(Collections.singletonList(author));
@@ -300,13 +302,13 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         expectedCommitResults.add(new CommitResult(author, "cfb3c8dc477cb0af19fce8bead4d278f35afa396",
                 parseGitStrictIsoDate("2020-04-20T12:09:39+08:00"),
                 "Create file name without special chars",
-                "", null, firstFileTypeAndContributionMap));
+                "", false, null, firstFileTypeAndContributionMap));
         Map<FileType, ContributionPair> secondFileTypeAndContributionMap = new HashMap<>();
         secondFileTypeAndContributionMap.put(FILETYPE_TXT, new ContributionPair(0, 0));
         expectedCommitResults.add(new CommitResult(author, "17bde492e9a80d8699ad193cf87e677341f936cc",
                 parseGitStrictIsoDate("2020-04-20T12:17:40+08:00"),
                 "Rename to file name with special chars",
-                "", null, secondFileTypeAndContributionMap));
+                "", false, null, secondFileTypeAndContributionMap));
 
         config.setBranch("1244-CommitInfoAnalyzerTest-analyzeCommits_fileNameWithSpecialChars_success");
         config.setAuthorList(Collections.singletonList(author));


### PR DESCRIPTION
Adding a --catch-non-pr-commits or -C flag when running Reposense.jar or adding a yes in the Catch Non PR Commits column in repo-config.csv will trigger reposense to detect the number of commits each person has made that did not go through a pull request. 

I remember that such commits in CS2103T are frowned upon a lot and noticed that reposense has no way of automatically catching such commits. After looking through developer tools in the browser I realized that github checks if a commit belongs to some pr through a certain URL and utilized that in the implementation of this enhancement.

I have only managed to implement the backend aspect of this and have yet to integrate it with the frontend. Proof that it works:

Commit which was directly pushed into repo without a pull request:
Commit URL: https://github.com/FH-30/Test-Repo/commit/ab16e85f7a2ce1a0b0f0ef364891f5473ed9423d

![Screen Shot 2021-07-01 at 7 08 07 PM](https://user-images.githubusercontent.com/61911161/124114868-ace0c900-da9f-11eb-9d03-a242fca9dccf.png)

Commit which went through a pull request:
Commit URL: https://github.com/FH-30/Test-Repo/commit/b21b50a5fba454dfc60353f2f9a068e58bb4555f

![Screen Shot 2021-07-01 at 7 09 33 PM](https://user-images.githubusercontent.com/61911161/124115027-e0235800-da9f-11eb-946e-cdd170f91364.png)

I have also compiled everything into a map which is displayed at the end of the commits.json file RepoSense generates as can be seen in the picture below:

![Screen Shot 2021-07-01 at 7 10 32 PM](https://user-images.githubusercontent.com/61911161/124115137-034e0780-daa0-11eb-93dc-629d1abe5643.png)

Commits.json file inside a zip file relevant to discussion: 
[commits.json.zip](https://github.com/FH-30/RepoSense/files/6747672/commits.json.zip)

I have yet to add tests, documentation and have not checked checkstyle tests. I won't mind doing it if you would like!

Hope this clarifies!